### PR TITLE
fix: path of brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information, visit the [official FizzBee repository](https://github.com
 ## Installation
 
 ```bash
-brew tap flaneur2020/fizzbee
+brew tap fizzbee-io/fizzbee
 brew install fizzbee
 ```
 


### PR DESCRIPTION
now the repo has been transfered to fizzbee-io, the path of `brew tap` should be updated as well